### PR TITLE
Overrode dependencies to allow for newer versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -412,7 +412,7 @@
                 "etag": "^1.8.1",
                 "fresh": "^0.5.2",
                 "fs-extra": "3.0.1",
-                "http-proxy": "1.15.2",
+                "http-proxy": ">=1.15.2",
                 "immutable": "^3",
                 "localtunnel": "1.9.2",
                 "micromatch": "^3.1.10",
@@ -426,7 +426,7 @@
                 "serve-index": "1.9.1",
                 "serve-static": "1.13.2",
                 "server-destroy": "1.0.1",
-                "socket.io": "2.1.1",
+                "socket.io": ">=2.1.1",
                 "ua-parser-js": "0.7.17",
                 "yargs": "6.4.0"
             },
@@ -2622,7 +2622,7 @@
             "integrity": "sha512-NEKF7bDJE9U3xzJu3kbayF0WTvng6Pww7tzqNb/XtEARYwqw7CKEX7BvOMg98FtE9es2CRizl61gkV3hS8dqYg==",
             "dev": true,
             "requires": {
-                "axios": "0.19.0",
+                "axios": ">=0.19.0",
                 "debug": "4.1.1",
                 "openurl": "1.1.1",
                 "yargs": "6.6.0"
@@ -4173,7 +4173,7 @@
             "dev": true,
             "requires": {
                 "chalk": "^1.1.1",
-                "object-path": "^0.9.0"
+                "object-path": ">=0.9.0"
             }
         },
         "to-array": {
@@ -4462,7 +4462,7 @@
                 "which-module": "^1.0.0",
                 "window-size": "^0.2.0",
                 "y18n": "^3.2.1",
-                "yargs-parser": "^4.1.0"
+                "yargs-parser": ">=4.1.0"
             }
         },
         "yargs-parser": {


### PR DESCRIPTION
Might be enough to fix the problem, probably a safer option